### PR TITLE
tz - Update multiPage param description

### DIFF
--- a/views/main.html
+++ b/views/main.html
@@ -270,11 +270,11 @@
 								</div>
 								<div
 									class="text-sm inline-block py-0.5 px-1 bg-teal-200 rounded-md mr-1">
-									false or 'min,max'
+									false or 'min-max'
 								</div>
 								<div
 									class="text-sm inline-block py-0.5 px-1 bg-yellow-200 rounded-md">
-									Eg. '2,4' will return all definitions from page 2 to page 4
+									Eg. '2-4' will return all definitions from page 2 to page 4
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
Using the multiPage param description as previously described (i.e. with a comma separating the two values) would return an error. As shown in the validation (https://github.com/kashyap010/unofficial-urban-dictionary-api/blob/master/src/utils/validateQueryParams.js), the valid input should be separated by a hyphen, so I updated the documentation to indicate that.