### PR TITLE
  Fix scraper crash due to Urban Dictionary contributor DOM change

### DIFF
--- a/src/utils/scraper.js
+++ b/src/utils/scraper.js
@@ -3,12 +3,19 @@ const cheerio = require("cheerio");
 const { getPreviousDate } = require("../utils/dateUtils");
 
 function extractDetails($, el) {
+	const $contributor = $(el).find(".contributor");
+	const links = $contributor.find("a");
+	const authorLink = links.length > 1 ? $(links[1]) : $(links[0]);
+	const lastTextNode = $contributor.contents().filter(function () {
+		return this.type === "text" && this.data.trim().length > 0;
+	}).last();
+
 	return {
 		word: $(el).find(".word").prop("innerText"),
 		meaning: $(el).find(".meaning").prop("innerText"),
 		example: $(el).find(".example").prop("innerText"),
-		contributor: $(el).find(".contributor a").prop("innerText"),
-		date: $(el).find(".contributor").contents()[2].data.trim(),
+		contributor: authorLink.prop("innerText") || "",
+		date: lastTextNode.length ? lastTextNode[0].data.trim() : "",
 	};
 }
 


### PR DESCRIPTION
  ## Summary
  - Fixes #8 — `extractDetails()` in `scraper.js` crashed with `Cannot read properties of undefined (reading 'trim')` because
   Urban Dictionary changed their `.contributor` markup
  - The contributor element now contains two `<a>` tags (word link + author link) instead of one, shifting the date text node
   from index `[2]` to `[3]`
  - Updated parsing to dynamically find the author link and last text node instead of relying on hardcoded indices

  ## Test plan
  - [x] `GET /api/search?term=scag` returns 200 with correct contributor and date fields
  - [ ] Verify `/api/random`, `/api/author`, `/api/browse`, `/api/date` endpoints still work

  Closes #8